### PR TITLE
Add confidential client helpers

### DIFF
--- a/scenarios/enterprise-mcp/Showcase.Authentication/Client/AuthorizationDelegatingHandler.cs
+++ b/scenarios/enterprise-mcp/Showcase.Authentication/Client/AuthorizationDelegatingHandler.cs
@@ -1,0 +1,184 @@
+using System.Net.Http.Headers;
+
+namespace Showcase.Authentication.Client;
+
+/// <summary>
+/// A delegating handler that adds authentication tokens to requests and handles 401 responses.
+/// </summary>
+public class AuthorizationDelegatingHandler : DelegatingHandler
+{
+    private readonly IConfidentialClientCredentialProvider _credentialProvider;
+    private string _currentScheme;
+    private static readonly char[] SchemeSplitDelimiters = { ' ', ',' };
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthorizationDelegatingHandler"/> class.
+    /// </summary>
+    /// <param name="credentialProvider">The provider that supplies authentication tokens.</param>
+    public AuthorizationDelegatingHandler(IConfidentialClientCredentialProvider credentialProvider)
+    {
+        ArgumentNullException.ThrowIfNull(credentialProvider);
+
+        _credentialProvider = credentialProvider;
+        
+        // Select first supported scheme as the default
+        _currentScheme = _credentialProvider.SupportedSchemes.FirstOrDefault() ??
+            throw new ArgumentException("Authorization provider must support at least one authentication scheme.", nameof(credentialProvider));
+    }
+
+    /// <summary>
+    /// Sends an HTTP request with authentication handling.
+    /// </summary>
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        if (request.Headers.Authorization == null)
+        {
+            await AddAuthorizationHeaderAsync(request, _currentScheme, cancellationToken).ConfigureAwait(false);
+        }
+
+        var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+        {
+            return await HandleUnauthorizedResponseAsync(request, response, cancellationToken).ConfigureAwait(false);
+        }
+
+        return response;
+    }
+
+    /// <summary>
+    /// Handles a 401 Unauthorized response by attempting to authenticate and retry the request.
+    /// </summary>
+    private async Task<HttpResponseMessage> HandleUnauthorizedResponseAsync(
+        HttpRequestMessage originalRequest, 
+        HttpResponseMessage response, 
+        CancellationToken cancellationToken)
+    {
+        // Gather the schemes the server wants us to use from WWW-Authenticate headers
+        var serverSchemes = ExtractServerSupportedSchemes(response);
+
+        // Find the intersection between what the server supports and what our provider supports
+        string? bestSchemeMatch = null;
+
+        // First try to find a direct match with the current scheme if it's still valid
+        string schemeUsed = originalRequest.Headers.Authorization?.Scheme ?? _currentScheme ?? string.Empty;
+        if (!string.IsNullOrEmpty(schemeUsed) && 
+            serverSchemes.Contains(schemeUsed) && 
+            _credentialProvider.SupportedSchemes.Contains(schemeUsed))
+        {
+            bestSchemeMatch = schemeUsed;
+        }
+        else
+        {
+            // Find the first server scheme that's in our supported set
+            bestSchemeMatch = serverSchemes.Intersect(_credentialProvider.SupportedSchemes, StringComparer.OrdinalIgnoreCase).FirstOrDefault();
+
+            // If no match was found, either throw an exception or use default
+            if (bestSchemeMatch is null)
+            {
+                if (serverSchemes.Count > 0)
+                {
+                    throw new IOException(
+                        $"The server does not support any of the provided authentication schemes." +
+                        $"Server supports: [{string.Join(", ", serverSchemes)}], " +
+                        $"Provider supports: [{string.Join(", ", _credentialProvider.SupportedSchemes)}].");
+                }
+
+                // If the server didn't specify any schemes, use the provider's default
+                bestSchemeMatch = _credentialProvider.SupportedSchemes.FirstOrDefault();
+            }
+        }
+
+        // If we have a scheme to try, use it
+        if (bestSchemeMatch != null)
+        {
+            // Try to handle the 401 response with the selected scheme
+            var (handled, recommendedScheme) = await _credentialProvider.HandleUnauthorizedResponseAsync(
+                response,
+                bestSchemeMatch,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!handled)
+            {
+                throw new InvalidOperationException(
+                    $"Failed to handle unauthorized response with scheme '{bestSchemeMatch}'. " +
+                    "The authentication provider was unable to process the authentication challenge.");
+            }
+            
+            _currentScheme = recommendedScheme ?? bestSchemeMatch;
+            
+            var retryRequest = new HttpRequestMessage(originalRequest.Method, originalRequest.RequestUri)
+            {
+                Version = originalRequest.Version,
+#if NET
+                VersionPolicy = originalRequest.VersionPolicy,
+#endif
+                Content = originalRequest.Content
+            };
+            
+            // Copy headers except Authorization which we'll set separately
+            foreach (var header in originalRequest.Headers)
+            {
+                if (!header.Key.Equals("Authorization", StringComparison.OrdinalIgnoreCase))
+                {
+                    retryRequest.Headers.TryAddWithoutValidation(header.Key, header.Value);
+                }
+            }
+#if NET
+            foreach (var property in originalRequest.Options)
+            {
+                retryRequest.Options.Set(new HttpRequestOptionsKey<object?>(property.Key), property.Value);
+            }
+#else
+            foreach (var property in originalRequest.Properties)
+            {
+                retryRequest.Properties.Add(property);
+            }
+#endif
+
+            // Add the new authorization header
+            await AddAuthorizationHeaderAsync(retryRequest, _currentScheme, cancellationToken).ConfigureAwait(false);
+            
+            // Send the retry request
+            return await base.SendAsync(retryRequest, cancellationToken).ConfigureAwait(false);
+        }
+        
+        return response; // Return the original response if we couldn't handle it
+    }
+
+    /// <summary>
+    /// Extracts the authentication schemes that the server supports from the WWW-Authenticate headers.
+    /// </summary>
+    private static HashSet<string> ExtractServerSupportedSchemes(HttpResponseMessage response)
+    {
+        var serverSchemes = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        
+        if (response.Headers.Contains("WWW-Authenticate"))
+        {
+            foreach (var authHeader in response.Headers.GetValues("WWW-Authenticate"))
+            {
+                // Extract the scheme from the WWW-Authenticate header
+                // Format is typically: "Scheme param1=value1, param2=value2"
+                string scheme = authHeader.Split(SchemeSplitDelimiters, StringSplitOptions.RemoveEmptyEntries)[0];
+                serverSchemes.Add(scheme);
+            }
+        }
+        
+        return serverSchemes;
+    }
+
+    /// <summary>
+    /// Adds an authorization header to the request.
+    /// </summary>
+    private async Task AddAuthorizationHeaderAsync(HttpRequestMessage request, string scheme, CancellationToken cancellationToken)
+    {
+        if (request.RequestUri != null)
+        {
+            var token = await _credentialProvider.GetCredentialAsync(scheme, request.RequestUri, cancellationToken).ConfigureAwait(false);
+            if (!string.IsNullOrEmpty(token))
+            {
+                request.Headers.Authorization = new AuthenticationHeaderValue(scheme, token);
+            }
+        }
+    }
+}

--- a/scenarios/enterprise-mcp/Showcase.Authentication/Client/AuthorizationHelpers.cs
+++ b/scenarios/enterprise-mcp/Showcase.Authentication/Client/AuthorizationHelpers.cs
@@ -1,0 +1,250 @@
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using System.Text.Json;
+
+namespace Showcase.Authentication.Client;
+
+/// <summary>
+/// Provides utility methods for handling authentication in MCP clients.
+/// </summary>
+public class AuthorizationHelpers
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger _logger;
+    private static readonly Lazy<HttpClient> _defaultHttpClient = new(() => new HttpClient());
+    
+    /// <summary>
+    /// The well-known path prefix for resource metadata.
+    /// </summary>
+    private static readonly string WellKnownPathPrefix = "/.well-known/";
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="AuthorizationHelpers"/> class.
+    /// </summary>
+    /// <param name="httpClient">The HTTP client to use for requests. If null, a default HttpClient will be used.</param>
+    /// <param name="logger">The logger to use. If null, a NullLogger will be used.</param>
+    public AuthorizationHelpers(HttpClient? httpClient = null, ILogger? logger = null)
+    {
+        _httpClient = httpClient ?? _defaultHttpClient.Value;
+        _logger = logger ?? NullLogger.Instance;
+    }
+
+    /// <summary>
+    /// Fetches the protected resource metadata from the provided URL.
+    /// </summary>
+    /// <param name="metadataUrl">The URL to fetch the metadata from.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The fetched ProtectedResourceMetadata, or null if it couldn't be fetched.</returns>
+    private async Task<ProtectedResourceMetadata?> FetchProtectedResourceMetadataAsync(
+        Uri metadataUrl, 
+        CancellationToken cancellationToken = default)
+    {
+        try
+        {
+            var request = new HttpRequestMessage(HttpMethod.Get, metadataUrl);
+            var response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+            
+            using var content = await response.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+            return await JsonSerializer.DeserializeAsync<ProtectedResourceMetadata>(
+                content,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, $"Failed to fetch protected resource metadata from {metadataUrl}");
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the resource URI in the metadata exactly matches the server URL as required by the RFC.
+    /// </summary>
+    /// <param name="protectedResourceMetadata">The metadata to verify.</param>
+    /// <param name="resourceLocation">The server URL to compare against.</param>
+    /// <returns>True if the resource URI exactly matches the server, otherwise false.</returns>
+    private static bool VerifyResourceMatch(ProtectedResourceMetadata protectedResourceMetadata, Uri resourceLocation)
+    {
+        if (protectedResourceMetadata.Resource == null || resourceLocation == null)
+        {
+            return false;
+        }
+
+        // Per RFC: The resource value must be identical to the URL that the client used
+        // to make the request to the resource server. Compare entire URIs, not just the host.
+        
+        // Normalize the URIs to ensure consistent comparison
+        string normalizedMetadataResource = NormalizeUri(protectedResourceMetadata.Resource);
+        string normalizedResourceLocation = NormalizeUri(resourceLocation);
+        
+        return string.Equals(normalizedMetadataResource, normalizedResourceLocation, StringComparison.OrdinalIgnoreCase);
+    }
+    
+    /// <summary>
+    /// Normalizes a URI for consistent comparison.
+    /// </summary>
+    /// <param name="uri">The URI to normalize.</param>
+    /// <returns>A normalized string representation of the URI.</returns>
+    private static string NormalizeUri(Uri uri)
+    {
+        var builder = new UriBuilder(uri)
+        {
+            Port = -1  // Always remove port
+        };
+        
+        if (builder.Path == "/")
+        {
+            builder.Path = string.Empty;
+        }
+        else if (builder.Path.Length > 1 && builder.Path.EndsWith("/"))
+        {
+            builder.Path = builder.Path.TrimEnd('/');
+        }
+        
+        return builder.Uri.ToString();
+    }
+
+    /// <summary>
+    /// Extracts the base resource URI from a well-known path URL.
+    /// </summary>
+    /// <param name="metadataUri">The metadata URI containing a well-known path.</param>
+    /// <returns>The base URI without the well-known path component.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the URI does not contain a valid well-known path.</exception>
+    private Uri ExtractBaseResourceUri(Uri metadataUri)
+    {
+        // Check for well-known path
+        int wellKnownIndex = metadataUri.AbsolutePath.IndexOf(WellKnownPathPrefix, StringComparison.OrdinalIgnoreCase);
+        
+        // Validate the URL contains a valid well-known path
+        if (wellKnownIndex < 0)
+        {
+            throw new InvalidOperationException(
+                $"Resource metadata URL '{metadataUri}' does not contain a valid well-known path format (/.well-known/)");
+        }
+        
+        // Create URI with just the base part
+        var baseUriBuilder = new UriBuilder(metadataUri)
+        {
+            Path = wellKnownIndex > 0 ? metadataUri.AbsolutePath.Substring(0, wellKnownIndex) : "/",
+            Fragment = string.Empty,
+            Query = string.Empty,
+            Port = -1 // Remove port
+        };
+        
+        // Ensure path ends with a slash
+        if (!baseUriBuilder.Path.EndsWith("/"))
+        {
+            baseUriBuilder.Path += "/";
+        }
+        
+        return baseUriBuilder.Uri;
+    }
+
+    /// <summary>
+    /// Responds to a 401 challenge by parsing the WWW-Authenticate header, fetching the resource metadata,
+    /// verifying the resource match, and returning the metadata if valid.
+    /// </summary>
+    /// <param name="response">The HTTP response containing the WWW-Authenticate header.</param>
+    /// <param name="serverUrl">The server URL to verify against the resource metadata.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>The resource metadata if the resource matches the server, otherwise throws an exception.</returns>
+    /// <exception cref="InvalidOperationException">Thrown when the response is not a 401, lacks a WWW-Authenticate header,
+    /// lacks a resource_metadata parameter, the metadata can't be fetched, or the resource URI doesn't match the server URL.</exception>
+    public async Task<ProtectedResourceMetadata> ExtractProtectedResourceMetadata(
+        HttpResponseMessage response,
+        Uri serverUrl,
+        CancellationToken cancellationToken = default)
+    {
+        if (response.StatusCode != System.Net.HttpStatusCode.Unauthorized)
+        {
+            throw new InvalidOperationException($"Expected a 401 Unauthorized response, but received {(int)response.StatusCode} {response.StatusCode}");
+        }
+
+        // Extract the WWW-Authenticate header
+        if (response.Headers.WwwAuthenticate.Count == 0)
+        {
+            throw new InvalidOperationException("The 401 response does not contain a WWW-Authenticate header");
+        }
+
+        // Look for the Bearer authentication scheme with resource_metadata parameter
+        string? resourceMetadataUrl = null;
+        foreach (var header in response.Headers.WwwAuthenticate)
+        {
+            if (string.Equals(header.Scheme, "Bearer", StringComparison.OrdinalIgnoreCase) && 
+                !string.IsNullOrEmpty(header.Parameter))
+            {
+                resourceMetadataUrl = ParseWwwAuthenticateParameters(header.Parameter, "resource_metadata");
+                if (resourceMetadataUrl != null)
+                {
+                    break;
+                }
+            }
+        }
+
+        if (resourceMetadataUrl == null)
+        {
+            throw new InvalidOperationException("The WWW-Authenticate header does not contain a resource_metadata parameter");
+        }
+
+        Uri metadataUri = new(resourceMetadataUrl);
+        
+        var metadata = await FetchProtectedResourceMetadataAsync(metadataUri, cancellationToken).ConfigureAwait(false);
+        if (metadata == null)
+        {
+            throw new InvalidOperationException($"Failed to fetch resource metadata from {resourceMetadataUrl}");
+        }
+        
+        // Extract the base URI from the metadata URL
+        Uri urlToValidate = ExtractBaseResourceUri(metadataUri);
+        _logger.LogDebug($"Validating resource metadata against base URL: {urlToValidate}");
+        
+        if (!VerifyResourceMatch(metadata, urlToValidate))
+        {
+            throw new InvalidOperationException(
+                $"Resource URI in metadata ({metadata.Resource}) does not match the expected URI ({urlToValidate})");
+        }
+
+        return metadata;
+    }
+
+    /// <summary>
+    /// Parses the WWW-Authenticate header parameters to extract a specific parameter.
+    /// </summary>
+    /// <param name="parameters">The parameter string from the WWW-Authenticate header.</param>
+    /// <param name="parameterName">The name of the parameter to extract.</param>
+    /// <returns>The value of the parameter, or null if not found.</returns>
+    private static string? ParseWwwAuthenticateParameters(string parameters, string parameterName)
+    {
+        if (parameters.IndexOf(parameterName, StringComparison.OrdinalIgnoreCase) == -1)
+        {
+            return null;
+        }
+
+        foreach (var part in parameters.Split(','))
+        {
+            string trimmedPart = part.Trim();
+            int equalsIndex = trimmedPart.IndexOf('=');
+            
+            if (equalsIndex <= 0)
+            {
+                continue;
+            }
+            
+            string key = trimmedPart.Substring(0, equalsIndex).Trim();
+            
+            if (string.Equals(key, parameterName, StringComparison.OrdinalIgnoreCase))
+            {
+                string value = trimmedPart.Substring(equalsIndex + 1).Trim();
+                
+                if (value.StartsWith("\"") && value.EndsWith("\""))
+                {
+                    value = value.Substring(1, value.Length - 2);
+                }
+                
+                return value;
+            }
+        }
+        
+        return null;
+    }
+}

--- a/scenarios/enterprise-mcp/Showcase.Authentication/Client/IConfidentialClientCredentialProvider.cs
+++ b/scenarios/enterprise-mcp/Showcase.Authentication/Client/IConfidentialClientCredentialProvider.cs
@@ -1,0 +1,48 @@
+namespace Showcase.Authentication.Client;
+
+/// <summary>
+/// Defines an interface for providing authentication for requests.
+/// This is the main extensibility point for authentication in MCP clients.
+/// </summary>
+public interface IConfidentialClientCredentialProvider
+{
+    /// <summary>
+    /// Gets the collection of authentication schemes supported by this provider.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property returns all authentication schemes that this provider can handle,
+    /// allowing clients to select the appropriate scheme based on server capabilities.
+    /// </para>
+    /// <para>
+    /// Common values include "Bearer" for JWT tokens, "Basic" for username/password authentication,
+    /// and "Negotiate" for integrated Windows authentication.
+    /// </para>
+    /// </remarks>
+    IEnumerable<string> SupportedSchemes { get; }
+
+    /// <summary>
+    /// Gets an authentication token or credential for authenticating requests to a resource
+    /// using the specified authentication scheme.
+    /// </summary>
+    /// <param name="scheme">The authentication scheme to use.</param>
+    /// <param name="resourceUri">The URI of the resource requiring authentication.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>An authentication token string or null if no token could be obtained for the specified scheme.</returns>
+    Task<string?> GetCredentialAsync(string scheme, Uri resourceUri, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Handles a 401 Unauthorized response from a resource.
+    /// </summary>
+    /// <param name="response">The HTTP response that contained the 401 status code.</param>
+    /// <param name="scheme">The authentication scheme that was used when the unauthorized response was received.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>
+    /// A result object indicating if the provider was able to handle the unauthorized response,
+    /// and the authentication scheme that should be used for the next attempt, if any.
+    /// </returns>
+    Task<UnauthorizedResponseResult> HandleUnauthorizedResponseAsync(
+        HttpResponseMessage response, 
+        string scheme,
+        CancellationToken cancellationToken = default);
+}

--- a/scenarios/enterprise-mcp/Showcase.Authentication/Client/UnauthorizedResponseResult.cs
+++ b/scenarios/enterprise-mcp/Showcase.Authentication/Client/UnauthorizedResponseResult.cs
@@ -1,0 +1,8 @@
+namespace Showcase.Authentication.Client;
+
+/// <summary>
+/// Represents the result of handling an unauthorized response from a resource.
+/// </summary>
+/// <param name="Success">Indicates if the provider was able to handle the unauthorized response.</param>
+/// <param name="RecommendedScheme">The authentication scheme that should be used for the next attempt, if any.</param>
+public record UnauthorizedResponseResult(bool Success, string? RecommendedScheme);

--- a/scenarios/enterprise-mcp/docs/Authentication.md
+++ b/scenarios/enterprise-mcp/docs/Authentication.md
@@ -102,5 +102,21 @@ The easiest way to combine this library with Azure AD (Entra ID) is via Microsof
 
 4. After this setup, any 401 responses from your API will include:
    ```
-   WWW-Authenticate: Bearer resource_metadata="https://api.yourdomain.com/.well-known/oauth-protected-resource"
-   ```
+WWW-Authenticate: Bearer resource_metadata="https://api.yourdomain.com/.well-known/oauth-protected-resource"
+```
+
+## Building a confidential client
+
+The `Showcase.Authentication.Client` namespace includes helpers for building
+clients that understand RFC 9728 challenges. Implement
+`IConfidentialClientCredentialProvider` to acquire tokens and register the
+`AuthorizationDelegatingHandler` with your `HttpClient`:
+
+```csharp
+var provider = new MyCredentialProvider();
+var http = new HttpClient(new AuthorizationDelegatingHandler(provider));
+```
+
+When a protected resource responds with a `WWW-Authenticate` header containing a
+`resource_metadata` parameter, the handler will fetch the metadata, invoke your
+credential provider, and retry the request with the proper credentials.


### PR DESCRIPTION
## Summary
- add client helpers to Showcase.Authentication for RFC 9728 challenges
- document how to build a confidential client

## Testing
- `dotnet build` *(fails: command not found)*